### PR TITLE
Fix de sidebar con highlight incorrecto

### DIFF
--- a/frontend/src/components/navbar/Sidebar.tsx
+++ b/frontend/src/components/navbar/Sidebar.tsx
@@ -34,8 +34,8 @@ export const Sidebar: React.FC<SidebarProps> = ({
    */
   useEffect(() => {
     if(location) {
-        let tmp = location.pathname.slice(location.pathname.lastIndexOf("/") +1, location.pathname.length);
-        setSelected(tmp);
+        let tmp = location.pathname.split('/').filter(Boolean).pop();
+        setSelected(tmp ?? defaultItem.value);
     }
   }, [location])
 


### PR DESCRIPTION
Agrega `useLocation` y `useEffect` para que el componente "sepa" en que parte se encuentra para destacar el elemento de la sidebar que corresponda.