### PR TITLE
✨ feat: add rebase as default pull method

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[pull]
+	rebase = yes


### PR DESCRIPTION
Agregar archivo de configuración para establecer `rebase` como método por defecto de pull, así no necesitan escribir `git pull --rebase` o evita que se les olvide escribirlo y no hagan rebase