### PR TITLE
Se agrega prop disabled opcional en DefaultRadioGroup

### DIFF
--- a/frontend/src/components/button/DefaultRadioGroup.tsx
+++ b/frontend/src/components/button/DefaultRadioGroup.tsx
@@ -11,10 +11,9 @@ export type RadioOption = {
 
 type RadioGroupProps = {
   name: string;
-  options: RadioOption[];
+  options: RadioOption[] | undefined;
   value: string;
   onChange: (value: string) => void;
-  isDisabled?: boolean;
 };
 
 const DefaultRadioGroup = ({
@@ -22,7 +21,6 @@ const DefaultRadioGroup = ({
   options,
   value,
   onChange,
-  isDisabled = false,
 }: RadioGroupProps) => {
   const handleRadioGroupChange = (
     event: React.ChangeEvent<HTMLInputElement>,
@@ -32,7 +30,7 @@ const DefaultRadioGroup = ({
 
   return (
     <div>
-      {!isDisabled
+      {options
         ? options.map(option => (
             <div className="mb-3" key={option.id}>
               <Radio


### PR DESCRIPTION
<!--- Proporciona un resumen general de tus cambios en el título -->

## Descripción
Se agrega el prop "isDisabled" opcional de tipo boolean al componente DefaultRadioGroup, el cual dependiendo su valor, se verá si se renderiza o no el componente radiogroup. 

## Motivación y Contexto
Actualmente si se usa el componente DefaultRadioGroup y no hay opciones, entonces aparece un error en el aplicativo, este arreglo busca que se maneje desde el componente padre si está habilitado o no el componente, esto permitiría evitar dicho problema en radio groups variables. 
No hay tickets relacionados.

## ¿Cómo ha sido probado?
Versión de node: 20.15.0

* El entorno de pruebas es el actual vulnerabilities-pareja3 (con data real).
* Las pruebas fueron realizadas con y sin elementos en el radriogroup y con elementos variables.

## Capturas de pantalla (si es apropiado):

Renderizado al usar radiogroup sin items/elementos:
![image](https://github.com/user-attachments/assets/fb90eec2-e8ec-4595-83fd-1fe6441b7d3d)



Renderizado con el cambio, donde el lado izquierdo no tiene "isDisabled" y el derecho lo tiene en "true":

![image](https://github.com/user-attachments/assets/558c0b08-07a0-44dc-be14-b8235a5058cb)


## Tipos de cambios
- [X] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [ ] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:
- [X] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere una modificación en la documentación.
- [ ] He actualizado la documentación en consecuencia.
