### PR TITLE
fix: z-index on overlapping components

### DIFF
--- a/frontend/src/components/input/SimpleInput.tsx
+++ b/frontend/src/components/input/SimpleInput.tsx
@@ -39,7 +39,7 @@ const SimpleInput: React.FC<SimpleInputProps> = ({
           {requiredField ? <span className="text-red-500 text-lg">*</span> : ''}
         </label>
       ) : null}
-      <div className="relative mt-2 rounded-md shadow-sm">
+      <div className="relative z-10 mt-2 rounded-md shadow-sm">
         <input
           className={`bg-gray-800 block w-full rounded-md py-1.5 p-2 placeholder:text-gray-400 sm:text-sm sm:leading-6 ${
             requiredAlert && value === '' && !isFocused

--- a/frontend/src/components/modal/Modal.tsx
+++ b/frontend/src/components/modal/Modal.tsx
@@ -24,7 +24,7 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   return (
     isOpen && (
-      <div className="fixed inset-0 flex items-center justify-center bg-stone-900 bg-opacity-50">
+      <div className="fixed z-50 inset-0 flex items-center justify-center bg-stone-900 bg-opacity-50">
         <div className="bg-gray-900 rounded-lg shadow-lg p-6 w-full max-w-lg">
           <div className="ml-3 mt-3 flex justify-between items-center mb-2">
             <h2 className="text-xl font-bold text-center text-gray-200">


### PR DESCRIPTION
<!--- Proporciona un resumen general de tus cambios en el título -->

## Descripción

El input se sobreponía al modal, así que se le asignó z-index a ambos para definir un orden de superposición. Se adjunta la [doc. de tailwind](https://tailwindcss.com/docs/z-index) donde se explica la funcionalidad utilizada.

Se agregó una sección a la wiki con los z-index de los componentes.

## Motivación y Contexto

Para evitar que al abrir un modal que utiliza className relative, los inputs que puedan haber en la pantalla principal se sobrepongan a este. 

## ¿Cómo ha sido probado?

En la rama de audits, abriendo el modal de creación de audit.

## Capturas de pantalla (si es apropiado):

ANTES:

![image](https://github.com/user-attachments/assets/e0520175-e52d-4317-b053-bc30218c04ae)

DESPUÉS:

![image](https://github.com/user-attachments/assets/c291c831-14f5-4829-8e78-3121ab1a03ee)


## Tipos de cambios
<!--- ¿Qué tipos de cambios introduce tu código? Pon una `x` en todas las casillas que apliquen: -->
- [x] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [ ] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:
<!--- Revisa todos los siguientes puntos, y pon una `x` en todas las casillas que apliquen. -->
<!--- Si no estás seguro sobre alguno de estos puntos, no dudes en preguntar. -->
- [x] Mi código sigue el estilo de código de este proyecto.
- [x] Mi cambio requiere una modificación en la documentación.
- [x] He actualizado la documentación en consecuencia.
