### PR TITLE
feat: add severity none to cvss calculator box

### DIFF
--- a/frontend/src/routes/vulnerabilities/components/scoreBox.tsx
+++ b/frontend/src/routes/vulnerabilities/components/scoreBox.tsx
@@ -13,6 +13,9 @@ const ScoreBox: React.FC<ScoreBoxProps> = ({ score, isComplete }) => {
   if (!isComplete) {
     rating = t('cvss.infoWhenNoScore');
     bgColor = 'bg-gray-500';
+  } else if (score === 0) {
+    rating = t('none');
+    bgColor = 'bg-[#53AA33]';
   } else if (score < 4) {
     rating = t('low');
     bgColor = 'bg-yellow-500';

--- a/frontend/src/routes/vulnerabilities/components/scoreBox.tsx
+++ b/frontend/src/routes/vulnerabilities/components/scoreBox.tsx
@@ -14,7 +14,7 @@ const ScoreBox: React.FC<ScoreBoxProps> = ({ score, isComplete }) => {
     rating = t('cvss.infoWhenNoScore');
     bgColor = 'bg-gray-500';
   } else if (score === 0) {
-    rating = t('none');
+    rating = t('cvss.none');
     bgColor = 'bg-[#53AA33]';
   } else if (score < 4) {
     rating = t('low');


### PR DESCRIPTION
<!--- Proporciona un resumen general de tus cambios en el título -->

## Descripción

<!--- Describe tus cambios en detalle -->
Se agrega la severidad informativa en el cvss calculator (severidad 0). Actualmente afecta al editar y añadir vulnerabilidades..

## Motivación y Contexto

<!--- ¿Por qué es necesario este cambio? ¿Qué problema soluciona? -->
<!--- Si soluciona un ticket abierto, por favor, enlaza el ticket aquí. -->
No hay un ticket sobre eso, pero es un problema actual.

## ¿Cómo ha sido probado?

<!--- Por favor, describe en detalle cómo probaste tus cambios. -->
<!--- Incluye detalles de tu entorno de prueba, y las pruebas que realizaste para -->
<!--- ver cómo tu cambio afecta otras áreas del código, etc. -->
Al editar y añadir vulnerabilidades se calcula algo con severidad 0, como se ve en la imagen adjunta:

## Capturas de pantalla (si es apropiado):

![image](https://github.com/user-attachments/assets/c88b6290-843f-4017-b75c-26ec5aec0f99)


## Tipos de cambios

<!--- ¿Qué tipos de cambios introduce tu código? Pon una `x` en todas las casillas que apliquen: -->

- [X] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [ ] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:

<!--- Revisa todos los siguientes puntos, y pon una `x` en todas las casillas que apliquen. -->
<!--- Si no estás seguro sobre alguno de estos puntos, no dudes en preguntar. -->

- [X] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere una modificación en la documentación.
- [ ] He actualizado la documentación en consecuencia.
- [ ] Requiere nuevos tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Nuevas Funciones**
	- Se añadió una lógica condicional en el componente `ScoreBox` para manejar el caso cuando la puntuación es 0 y `isComplete` es verdadero, mostrando un fondo verde y la traducción para 'ninguno'.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->