### PR TITLE
added customSections on audits

### DIFF
--- a/frontend/src/components/navbar/AuditSidebar.tsx
+++ b/frontend/src/components/navbar/AuditSidebar.tsx
@@ -1,8 +1,20 @@
+/* eslint-disable import/extensions */
+/* eslint-disable sonarjs/no-duplicate-string */
 import clsx from 'clsx';
 import { t } from 'i18next';
-import { ChevronDown, ChevronUp, Users } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  FilePlus2,
+  Plus,
+  Users,
+} from 'lucide-react';
 import { Link } from 'react-router-dom';
 
+import { AuditSection } from '@/services/audits';
+
+import { Section } from '../../services/data';
 import DefaultRadioGroup from '../button/DefaultRadioGroup';
 import SelectDropdown from '../dropdown/SelectDropdown';
 
@@ -42,6 +54,10 @@ type AuditSidebarProps = {
   setActiveItem: (item: string) => void;
   isCollapsed: boolean;
   setIsCollapsed: (collapsed: boolean) => void;
+  isListVisible: boolean;
+  setIsListVisible: (visible: boolean) => void;
+  auditSections: AuditSection[];
+  sections: Section[];
   sortBy: SortOption | null;
   setSortBy: (option: SortOption | null) => void;
   sortOrder: string;
@@ -56,8 +72,12 @@ type AuditSidebarProps = {
 const AuditSidebar = ({
   activeItem,
   setActiveItem,
+  auditSections,
   isCollapsed,
   setIsCollapsed,
+  isListVisible,
+  setIsListVisible,
+  sections,
   sortBy,
   setSortBy,
   sortOrder,
@@ -163,6 +183,100 @@ const AuditSidebar = ({
         </ul>
       </div>
     </nav>
+    <div className="p-4 border-t border-gray-800">
+      <div className="mb-2 flex gap-2">
+        <button
+          className="w-full flex items-center justify-start gap-3 text-gray-400 hover:text-gray-100 hover:bg-gray-800 px-4 py-2 rounded-lg transition-colors duration-200 whitespace-nowrap"
+          type="button"
+        >
+          <FilePlus2 className="h-5 w-5 flex-shrink-0" />
+          <span
+            className={clsx(
+              'transition-opacity',
+              isCollapsed && 'opacity-0 w-0 overflow-hidden',
+            )}
+          >
+            {t('customSections')}
+          </span>
+        </button>
+        {!isCollapsed ? (
+          <button
+            className="flex items-center justify-center text-gray-400 hover:text-gray-100 hover:bg-gray-800 rounded-full transition-colors duration-200 w-10 h-10"
+            onClick={() => setIsListVisible(!isListVisible)}
+            type="button"
+          >
+            <Plus className="h-5 w-5 flex-shrink-0" />
+          </button>
+        ) : null}
+        <div className="relative">
+          {isListVisible ? (
+            <ul
+              className="absolute z-10 mt-2 bg-gray-800 rounded-lg p-2 space-y-1 shadow-lg border border-gray-700"
+              style={{ minWidth: '200px' }}
+            >
+              {sections.map(section => {
+                const isSelected = auditSections.some(
+                  auditSection => auditSection.field === section.field,
+                );
+
+                return (
+                  <button
+                    className={clsx(
+                      'w-full text-left text-gray-300 hover:bg-gray-700 rounded-md p-2 flex items-center gap-2',
+                      isSelected && 'bg-gray-700 text-white',
+                    )}
+                    key={section.field}
+                    onClick={() => setIsListVisible(!isListVisible)}
+                    type="button"
+                  >
+                    {section.icon.startsWith('fa-') ? (
+                      <i className={`fa ${section.icon}`} />
+                    ) : (
+                      <i className="material-icons">{section.icon}</i>
+                    )}
+                    <span>{section.name}</span>
+                    {isSelected ? (
+                      <Check className="h-5 w-5 flex-shrink-0 ml-auto " />
+                    ) : null}
+                  </button>
+                );
+              })}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+
+      {!isCollapsed ? (
+        <ul className="space-y-2">
+          {auditSections.map(section => (
+            <li key={section.name}>
+              <Link
+                className={clsx(
+                  'flex items-center gap-2 text-sm w-full justify-start px-4 py-2 text-left font-medium rounded-lg transition-colors duration-200',
+                  activeItem === section.name
+                    ? 'bg-gray-800 text-white'
+                    : 'text-gray-400',
+                  'hover:bg-gray-800',
+                )}
+                onClick={() => {
+                  setActiveItem(section.name);
+                }}
+                to={`sections/${section._id}`}
+              >
+                {section.icon && section.icon.startsWith('fa-') ? (
+                  <i className={`fa ${section.icon}`} />
+                ) : (
+                  <i className="material-icons">{section.icon}</i>
+                )}
+                <span className={clsx('flex-1 transition-opacity')}>
+                  {section.name}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
     <div className="p-4 border-t border-gray-800">
       <div className="mb-2">
         <button

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -21,7 +21,14 @@ import {
   Settings,
   Vulnerabilities,
 } from './routes';
-import { Add, AuditRoot, Edit, General, Network } from './routes/audits';
+import {
+  Add,
+  AuditRoot,
+  Edit,
+  General,
+  Network,
+  Sections,
+} from './routes/audits';
 import {
   Clients,
   Collaborators,
@@ -65,6 +72,10 @@ const router = createBrowserRouter([
           {
             path: 'findings/:findingId',
             element: <Edit />,
+          },
+          {
+            path: 'sections/:sectionId',
+            element: <Sections />,
           },
         ],
       },

--- a/frontend/src/routes/audits/edit/sections/AuditCustomFields.tsx
+++ b/frontend/src/routes/audits/edit/sections/AuditCustomFields.tsx
@@ -1,0 +1,242 @@
+/* eslint-disable import/extensions */
+import { t } from 'i18next';
+
+import DefaultRadioGroup from '@/components/button/DefaultRadioGroup';
+import SimpleInput from '@/components/input/SimpleInput';
+import RichText from '@/components/text/RichText';
+import {
+  CheckboxButtonCustom,
+  DayPickerCustom,
+  MultiSelectDropdownCustom,
+  SelectDropdownCustom,
+} from '@/routes/data/CustomData/custom-fields/customComponents';
+
+type TransformedField = {
+  description: string;
+  display: string;
+  displaySub: string;
+  fieldType: string;
+  label: string;
+  offset: number;
+  text: {
+    locale: string;
+    value: string;
+  }[];
+  options: {
+    locale: string;
+    value: string;
+  }[];
+  required: boolean;
+  size: number;
+  _id: string;
+};
+
+type ListItem = {
+  id: number;
+  value: string;
+  label?: string;
+  locale?: string;
+};
+
+type AuditCustomFieldsProps = {
+  fields: TransformedField[];
+  currentLanguage: ListItem;
+  // es necesaria una refactorización de los componentes
+  // se hará un issue al respecto
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  setCurrentCustomFields: (fields: any) => void;
+  onSave: () => void;
+};
+
+const AuditCustomFields: React.FC<AuditCustomFieldsProps> = ({
+  fields,
+  currentLanguage,
+  setCurrentCustomFields,
+  onSave,
+}) => {
+  const handlerInputChangeText = (id: string, value: string) => {
+    setCurrentCustomFields((prevFields: TransformedField[]) => {
+      return prevFields.map((field: TransformedField) =>
+        field._id === id
+          ? {
+              ...field,
+              text: field.text.map(item =>
+                item.locale === currentLanguage.value
+                  ? { locale: item.locale, value }
+                  : item,
+              ),
+            }
+          : field,
+      );
+    });
+  };
+
+  const handlerTextString = (
+    text: { locale: string; value: string | string[] }[],
+  ) => {
+    return Array.isArray(text[0].value) ? text[0].value[0] : text[0].value;
+  };
+
+  const handlerTextArray = (
+    text: {
+      locale: string;
+      value: string | string[];
+    }[],
+  ) => {
+    return text
+      .filter(item => item.locale === currentLanguage.value)
+      .flatMap(item => (Array.isArray(item.value) ? item.value : [item.value]));
+  };
+
+  return (
+    <div>
+      <div className="flex justify-end mt-4">
+        <button
+          className="bg-blue-500 text-white rounded-md px-4 py-2"
+          onClick={onSave}
+          type="button"
+        >
+          {t('btn.save')}
+        </button>
+      </div>
+      {fields.map(customField => {
+        const { _id, fieldType, size, offset, options, label, text } =
+          customField;
+        const validSize = Math.min(12, Math.max(0, size));
+        const sizeStyle =
+          validSize > 0
+            ? Math.round((validSize / 12) * 100)
+            : Math.round((1 / 12) * 100);
+
+        return (
+          <div
+            className="bg-[#101827] shadow-md rounded-lg p-4 my-4"
+            key={_id}
+            style={{ width: '100%' }}
+          >
+            <span className="block font-medium leading-6 text-white-600">
+              {label}
+            </span>
+            <span className="block font-medium leading-6 text-white-600">
+              {t('offset')}: {offset}
+            </span>
+
+            <div className="mt-4" style={{ width: `calc(${sizeStyle}%)` }}>
+              {(() => {
+                switch (fieldType) {
+                  case 'checkbox':
+                    return (
+                      <CheckboxButtonCustom
+                        currentLanguage={currentLanguage.value}
+                        id={_id}
+                        options={options.map(option => option.value)}
+                        setCurrentCustomFields={setCurrentCustomFields}
+                        text={handlerTextArray(text)}
+                      />
+                    );
+
+                  case 'space':
+                    return (
+                      <div className="bg-white w-full rounded-lg mt-1 h-28" />
+                    );
+
+                  case 'text':
+                    return (
+                      <RichText
+                        label=""
+                        onChange={(value: string) =>
+                          handlerInputChangeText(_id, value)
+                        }
+                        placeholder=""
+                        value={handlerTextString(text)}
+                      />
+                    );
+
+                  case 'input':
+                    return (
+                      <SimpleInput
+                        id={_id}
+                        name={_id}
+                        onChange={(value: string) =>
+                          handlerInputChangeText(_id, value)
+                        }
+                        placeholder=""
+                        type="text"
+                        value={handlerTextString(text)}
+                      />
+                    );
+
+                  case 'radio':
+                    return (
+                      <DefaultRadioGroup
+                        name={_id}
+                        onChange={(value: string) =>
+                          handlerInputChangeText(_id, value)
+                        }
+                        options={options.map((option, index) => ({
+                          id: index.toString(),
+                          label: option.value,
+                          value: option.value,
+                        }))}
+                        value={handlerTextString(text)}
+                      />
+                    );
+
+                  case 'select':
+                    return (
+                      <SelectDropdownCustom
+                        currentLanguage={currentLanguage.value}
+                        id={_id}
+                        items={options.map((option, index) => ({
+                          id: index,
+                          value: option.value,
+                          label: option.value,
+                        }))}
+                        placeholder="Select"
+                        setCurrentCustomFields={setCurrentCustomFields}
+                        text={handlerTextString(text)}
+                        title=""
+                      />
+                    );
+
+                  case 'select-multiple':
+                    return (
+                      <MultiSelectDropdownCustom
+                        currentLanguage={currentLanguage.value}
+                        id={_id}
+                        items={options.map((option, index) => ({
+                          id: index,
+                          value: option.value,
+                          label: option.value,
+                        }))}
+                        placeholder="Select"
+                        setCurrentCustomFields={setCurrentCustomFields}
+                        text={handlerTextArray(text)}
+                        title=""
+                      />
+                    );
+
+                  case 'date':
+                    return (
+                      <DayPickerCustom
+                        currentLanguage={currentLanguage.value}
+                        id={_id}
+                        label=""
+                        setCurrentCustomFields={setCurrentCustomFields}
+                        text={handlerTextString(text)}
+                      />
+                    );
+
+                  default:
+                    return null;
+                }
+              })()}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AuditCustomFields;

--- a/frontend/src/routes/audits/edit/sections/sections.tsx
+++ b/frontend/src/routes/audits/edit/sections/sections.tsx
@@ -1,3 +1,196 @@
+/* eslint-disable import/extensions */
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+import {
+  AuditSectionById,
+  getAuditById,
+  getAuditSectionById,
+  getLanguages,
+  updateAuditSectionById,
+} from '@/services/audits';
+
+import AuditCustomFields from './AuditCustomFields';
+
+type LanguageData = {
+  language: string;
+  locale: string;
+};
+
+type ListItem = {
+  id: number;
+  value: string;
+  label?: string;
+  icon?: string;
+};
+
+type TransformedField = {
+  description: string;
+  display: string;
+  displaySub: string;
+  fieldType: string;
+  label: string;
+  offset: number;
+  text: {
+    locale: string;
+    value: string;
+  }[];
+  options: {
+    locale: string;
+    value: string;
+  }[];
+  required: boolean;
+  size: number;
+  _id: string;
+};
+
 export const Sections = () => {
-  return <div className="p-4">Sections</div>;
+  const [currentCustomFields, setCurrentCustomFields] = useState<
+    TransformedField[]
+  >([]);
+  const [languagesList, setLanguagesList] = useState<ListItem[]>([]);
+  const [auditLanguage, setAuditLanguage] = useState<string | null>(null);
+  const [currentLanguage, setCurrentLanguage] = useState<ListItem>();
+  const [dataAuditSection, setDataAuditSection] = useState<AuditSectionById>();
+
+  const auditId = useParams().auditId;
+  const sectionId = useParams().sectionId;
+
+  const fetchLanguages = async () => {
+    try {
+      const dataLanguage = await getLanguages();
+      const languageNames = dataLanguage.datas.map(
+        (item: LanguageData, index: number) => ({
+          id: index,
+          value: item.locale,
+          label: item.language,
+        }),
+      );
+      setLanguagesList(languageNames);
+    } catch (error) {
+      console.error('Error:', error);
+    }
+  };
+
+  const fetchAudit = useCallback(async () => {
+    try {
+      const audit = await getAuditById(auditId);
+      setAuditLanguage(audit.datas.language);
+    } catch (error) {
+      console.error('Error:', error);
+    }
+  }, [auditId]);
+
+  const fetchAuditSections = useCallback(async () => {
+    if (!currentLanguage) {
+      return;
+    }
+
+    try {
+      const auditSectionResponse = await getAuditSectionById(
+        auditId,
+        sectionId,
+      );
+
+      setDataAuditSection(auditSectionResponse.datas);
+    } catch (error) {
+      console.error('Error:', error);
+    }
+  }, [auditId, sectionId, currentLanguage]);
+
+  useEffect(() => {
+    if (dataAuditSection && currentLanguage) {
+      const transformedFields = dataAuditSection.customFields.map(field => ({
+        description: field.customField.description,
+        display: field.customField.display,
+        displaySub: field.customField.displaySub,
+        fieldType: field.customField.fieldType,
+        label: field.customField.label,
+        offset: field.customField.offset,
+        text: Array.isArray(field.text)
+          ? field.text.map(textItem => ({
+              locale: currentLanguage.value,
+              value: textItem,
+            }))
+          : [{ locale: currentLanguage.value, value: field.text }],
+        options: field.customField.options.map(optionItem => ({
+          locale: optionItem.locale,
+          value: optionItem.value,
+        })),
+        required: field.customField.required,
+        size: field.customField.size,
+        _id: field.customField._id,
+      }));
+      setCurrentCustomFields(transformedFields);
+    }
+  }, [dataAuditSection, currentLanguage]);
+
+  useEffect(() => {
+    void fetchLanguages();
+  }, []);
+
+  useEffect(() => {
+    void fetchAudit();
+  }, [fetchAudit]);
+
+  useEffect(() => {
+    if (currentLanguage) {
+      void fetchAuditSections();
+    }
+  }, [currentLanguage, fetchAuditSections]);
+
+  useEffect(() => {
+    if (auditLanguage && languagesList.length > 0) {
+      const matchedLanguage = languagesList.find(
+        language => language.label === auditLanguage,
+      );
+      setCurrentLanguage(matchedLanguage);
+    }
+  }, [auditLanguage, languagesList]);
+
+  const handleSave = () => {
+    if (!dataAuditSection) {
+      return;
+    }
+
+    const transformedFields = currentCustomFields.map(field => {
+      const { text, ...customField } = field;
+
+      const textValues = text.map(item => item.value).flat();
+      const formattedText =
+        customField.fieldType === 'checkbox' ||
+        customField.fieldType === 'select-multiple'
+          ? textValues
+          : textValues.length === 1
+            ? textValues[0]
+            : textValues;
+
+      return {
+        customField,
+        text: formattedText,
+      };
+    });
+
+    const payload = {
+      customFields: transformedFields,
+      field: dataAuditSection.field,
+      name: dataAuditSection.name,
+      _id: dataAuditSection._id,
+    };
+
+    void updateAuditSectionById(auditId, sectionId, payload);
+  };
+
+  return (
+    <div className="p-4">
+      {currentLanguage ? (
+        <AuditCustomFields
+          currentLanguage={currentLanguage}
+          fields={currentCustomFields}
+          onSave={handleSave}
+          setCurrentCustomFields={setCurrentCustomFields}
+        />
+      ) : null}
+    </div>
+  );
 };

--- a/frontend/src/routes/audits/index.tsx
+++ b/frontend/src/routes/audits/index.tsx
@@ -3,5 +3,6 @@ import { Add } from './edit/findings/add/add';
 import { Edit } from './edit/findings/edit/edit';
 import { General } from './edit/general/general';
 import { Network } from './edit/network/network';
+import { Sections } from './edit/sections/sections';
 
-export { Add, AuditRoot, Edit, General, Network };
+export { Add, AuditRoot, Edit, General, Network, Sections };

--- a/frontend/src/services/audits.ts
+++ b/frontend/src/services/audits.ts
@@ -36,6 +36,14 @@ export type FindingByLocale = {
   category?: string;
 };
 
+export type AuditSection = {
+  field: string;
+  name: string;
+  _id: string;
+  customFields: string[];
+  icon?: string;
+};
+
 export type Audit = {
   _id: string;
   name: string;
@@ -113,7 +121,7 @@ export type AuditById = {
     updatedAt: string;
     __v: number;
   } | null;
-  sections: string[];
+  sections: AuditSection[];
   customFields: string[];
   sortFindings: string[];
   scope: {
@@ -123,6 +131,56 @@ export type AuditById = {
   findings: Finding[];
   date_end: string;
   date_start: string;
+};
+
+export type UpdateAuditCustomFields = {
+  customFields: {
+    customField: {
+      description: string;
+      display: string;
+      displaySub: string;
+      fieldType: string;
+      label: string;
+      offset: number;
+      options: {
+        locale: string;
+        value: string;
+      }[];
+      required: boolean;
+      size: number;
+      _id: string;
+    };
+    text: string | string[];
+  }[];
+  field: string;
+  name: string;
+  _id: string;
+};
+
+export type SectionCustomField = {
+  description: string;
+  display: string;
+  displaySub: string;
+  fieldType: string;
+  label: string;
+  offset: number;
+  options: {
+    locale: string;
+    value: string;
+  }[];
+  required: boolean;
+  size: number;
+  _id: string;
+};
+
+export type AuditSectionById = {
+  _id: string;
+  field: string;
+  name: string;
+  customFields: {
+    customField: SectionCustomField;
+    text: string | string[];
+  }[];
 };
 
 export type NewAudit = {
@@ -383,6 +441,54 @@ export const getAuditById = async (
   }
 };
 
+export const getAuditSectionById = async (
+  auditId: string | undefined,
+  sectionId: string | undefined,
+): Promise<{ status: string; datas: AuditSectionById }> => {
+  try {
+    const response = await fetch(
+      `${API_URL}audits/${auditId}/sections/${sectionId}`,
+      {
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+      },
+    );
+    if (!response.ok) {
+      throw networkError;
+    }
+    return await response.json();
+  } catch (error) {
+    console.error(error);
+
+    throw error;
+  }
+};
+
+export const updateAuditSectionById = async (
+  auditId: string | undefined,
+  sectionId: string | undefined,
+  auditSections: UpdateAuditCustomFields,
+): Promise<{ status: string; datas: AuditSectionById }> => {
+  try {
+    const response = await fetch(
+      `${API_URL}audits/${auditId}/sections/${sectionId}`,
+      {
+        method: 'PUT',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(auditSections),
+      },
+    );
+    if (!response.ok) {
+      throw networkError;
+    }
+    return await response.json();
+  } catch (error) {
+    console.error(error);
+
+    throw error;
+  }
+};
 export const getAuditColumns = async (): Promise<
   {
     header: string;

--- a/frontend/src/services/data.ts
+++ b/frontend/src/services/data.ts
@@ -166,6 +166,12 @@ export type NewCustomSection = {
   icon?: string;
 };
 
+export type Section = {
+  field: string;
+  name: string;
+  icon: string;
+};
+
 const networkErrorMsg = 'Network response was not ok';
 
 export const getRoles = async (): Promise<{
@@ -577,7 +583,7 @@ export const updateTemplate = async (
 
 export const getCustomSections = async (): Promise<{
   status: string;
-  datas: { field: string; name: string; icon: string }[];
+  datas: Section[];
 }> => {
   try {
     const response = await fetch(`${API_URL}data/sections`, {


### PR DESCRIPTION
<!--- Proporciona un resumen general de tus cambios en el título -->

## Descripción

Se agregan vistas para la edición de customSections en audits.

## Motivación y Contexto

Permite la modificación específica para cada audit de los customSections (asociados a uno o varios customField)

## ¿Cómo ha sido probado?

_npm run build_
A través de la misma vista, editando cada campo.

## Capturas de pantalla (si es apropiado):

## Tipos de cambios

- [ ] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [ X ] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:

<!--- Revisa todos los siguientes puntos, y pon una `x` en todas las casillas que apliquen. -->
<!--- Si no estás seguro sobre alguno de estos puntos, no dudes en preguntar. -->

- [ X ] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere una modificación en la documentación.
- [ ] He actualizado la documentación en consecuencia.
- [ ] Requiere nuevos tests.
