### PR TITLE
fix: remove primary button in popover trigger

### DIFF
--- a/frontend/src/routes/data/CustomData/custom-fields/customComponents/PopOverEditCustomField.tsx
+++ b/frontend/src/routes/data/CustomData/custom-fields/customComponents/PopOverEditCustomField.tsx
@@ -160,10 +160,8 @@ export const PopOverEditCustomField: React.FC<PopOverProps> = ({
   return (
     <div>
       <Popover>
-        <PopoverTrigger className="flex h-10">
-          <PrimaryButton color="blue">
-            <PencilSquareIcon className="h-5 w-5" />
-          </PrimaryButton>
+        <PopoverTrigger className="flex max-h-10 bg-blue-800 hover:bg-blue-700 mt-1 py-2 px-4 rounded focus:outline-none focus:shadow-outline">
+          <PencilSquareIcon className="h-5 w-5" />
         </PopoverTrigger>
         <PopoverContent className="bg-gray-700">
           <div className="text-white flex flex-col">


### PR DESCRIPTION
<!--- Proporciona un resumen general de tus cambios en el título -->

## Descripción

<!--- Describe tus cambios en detalle -->
Se quita el primary button del pop over, el cual provocaba el error que aparece en las capturas adjuntas

## Motivación y Contexto

<!--- ¿Por qué es necesario este cambio? ¿Qué problema soluciona? -->
<!--- Si soluciona un ticket abierto, por favor, enlaza el ticket aquí. -->

Soluciona un problema mencionado de manera interna.

## ¿Cómo ha sido probado?

<!--- Por favor, describe en detalle cómo probaste tus cambios. -->
<!--- Incluye detalles de tu entorno de prueba, y las pruebas que realizaste para -->
<!--- ver cómo tu cambio afecta otras áreas del código, etc. -->
Para probar se debe agregar un custom field y comprobar que no se vea el error en la consola.

## Capturas de pantalla (si es apropiado):

![image](https://github.com/user-attachments/assets/e012e23c-5473-4196-bf73-1c937b8d9260)

## Tipos de cambios

<!--- ¿Qué tipos de cambios introduce tu código? Pon una `x` en todas las casillas que apliquen: -->

- [X] Bugfix (cambio que no interrumpe el funcionamiento y que soluciona un problema)
- [ ] New feature (cambio que no interrumpe el funcionamiento y que añade funcionalidad)
- [ ] Breaking change (corrección o funcionalidad que podría causar que la funcionalidad existente cambie)

## Lista de verificación:

<!--- Revisa todos los siguientes puntos, y pon una `x` en todas las casillas que apliquen. -->
<!--- Si no estás seguro sobre alguno de estos puntos, no dudes en preguntar. -->

- [X] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere una modificación en la documentación.
- [ ] He actualizado la documentación en consecuencia.
- [ ] Requiere nuevos tests.
